### PR TITLE
Fix channel_name and install_from metric names doesn't match.

### DIFF
--- a/Source/FirefoxRealityUnity/metrics.yaml
+++ b/Source/FirefoxRealityUnity/metrics.yaml
@@ -6,7 +6,7 @@
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
 distribution:
-  channel_name:
+  fxr_channel_name:
     type: string
     description: >
       The distribution channel name of this application.
@@ -16,14 +16,16 @@ distribution:
       - launch
     bugs:
       - https://github.com/MozillaReality/FirefoxRealityPC/pull/198
+      - https://github.com/MozillaReality/FirefoxRealityPC/pull/203
     data_reviews:
       - https://github.com/MozillaReality/FirefoxRealityPC/pull/198#issuecomment-657786864
+      - https://github.com/MozillaReality/FirefoxRealityPC/pull/203#issuecomment-710564366
     notification_emails:
       - fxr-telemetry@mozilla.com
       - dmu@mozilla.com
     expires: "2021-01-01"
 
-  install_from:
+  ff_install_from:
     type: string
     description: >
       The way of users gets Firefox desktop for running with Firefox Reality,
@@ -32,8 +34,10 @@ distribution:
       - launch
     bugs:
       - https://github.com/MozillaReality/FirefoxRealityPC/pull/198
+      - https://github.com/MozillaReality/FirefoxRealityPC/pull/203
     data_reviews:
       - https://github.com/MozillaReality/FirefoxRealityPC/pull/198#issuecomment-657786864
+      - https://github.com/MozillaReality/FirefoxRealityPC/pull/203#issuecomment-710564366
     notification_emails:
       - fxr-telemetry@mozilla.com
       - dmu@mozilla.com

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -29,8 +29,8 @@ The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration |
 | --- | --- | --- | --- | --- | --- |
-| distribution.channel_name |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The distribution channel name of this application. We use this field to recognize Firefox Reality is distributed to which channels, such as htc, etc.  |[1](https://github.com/MozillaReality/FirefoxRealityPC/pull/198#issuecomment-657786864)||2021-01-01 |
-| distribution.install_from |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The way of users gets Firefox desktop for running with Firefox Reality, such as embedded, downloaded, etc.  |[1](https://github.com/MozillaReality/FirefoxRealityPC/pull/198#issuecomment-657786864)||2021-01-01 |
+| distribution.ff_install_from |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The way of users gets Firefox desktop for running with Firefox Reality, such as embedded, downloaded, etc.  |[1](https://github.com/MozillaReality/FirefoxRealityPC/pull/198#issuecomment-657786864), [2](https://github.com/MozillaReality/FirefoxRealityPC/pull/203#issuecomment-710564366)||2021-01-01 |
+| distribution.fxr_channel_name |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The distribution channel name of this application. We use this field to recognize Firefox Reality is distributed to which channels, such as htc, etc.  |[1](https://github.com/MozillaReality/FirefoxRealityPC/pull/198#issuecomment-657786864), [2](https://github.com/MozillaReality/FirefoxRealityPC/pull/203#issuecomment-710564366)||2021-01-01 |
 | launch.entry_method |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |Determining how a user launches Firefox Reality application, such as system_button, library, gaze, etc.  |[1](https://github.com/MozillaReality/FirefoxRealityPC/pull/198#issuecomment-657786864)||2021-01-01 |
 
 


### PR DESCRIPTION
Fixes #202.

We have to make the metrics category/names as declared in the ManualMetrics.cs match to the official registry files.